### PR TITLE
[DCK] Disable robots in demos

### DIFF
--- a/test.yaml
+++ b/test.yaml
@@ -18,6 +18,8 @@ services:
             globalwhitelist_shared:
             inverseproxy_shared:
         labels:
+            traefik.frontend.headers.customResponseHeaders:
+                "X-Robots-Tag:noindex, nofollow"
             traefik.dbmanager.frontend.auth.basic:
                 "${DB_USER}:${ODOO_ADMIN_PASSWORD_BCRYPT}"
             traefik.dbmanager.frontend.rule:


### PR DESCRIPTION
By default, test environments should not be scanned by search engines.

Here I apply the Google-recommended HTTP header by default
for folks using Traefik.