### PR TITLE
[DCK] Use correct ptvsd argument

### DIFF
--- a/devel.yaml
+++ b/devel.yaml
@@ -29,7 +29,7 @@ services:
                 COMPILE: "false"
         environment:
             ADMIN_PASSWORD: admin
-            ENABLE_PTVSD: "${DOODBA_ENABLE_PTVSD:-0}"
+            PTVSD_ENABLE: "${DOODBA_PTVSD_ENABLE:-0}"
             PGDATABASE: devel
             PYTHONOPTIMIZE: ""
             SMTP_PORT: "1025"


### PR DESCRIPTION
[The docs][1] say that you have to use `$DOODBA_PTVSD_ENABLE`. A typo introduced in https://github.com/Tecnativa/doodba-scaffolding/pull/4 rendered those instructions as not working.

With this commit, ptvsd enablement should be done correctly.

It will not work, however, until https://github.com/Tecnativa/doodba/pull/167 is merged and images are built, but that's a bug in doodba itself.

[1]: https://github.com/Tecnativa/doodba#ptvsd