### PR TITLE
[DCK] Use $INITIAL_LANG only in prod

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -8,7 +8,6 @@ services:
                 ODOO_VERSION: $ODOO_MINOR
         environment:
             ADMIN_PASSWORD: "$ODOO_ADMIN_PASSWORD"
-            INITIAL_LANG: "$INITIAL_LANG"
             PGPASSWORD: "$DB_PASSWORD"
             PGUSER: "$DB_USER"
             DB_FILTER: "$DB_FILTER"

--- a/prod.yaml
+++ b/prod.yaml
@@ -5,6 +5,8 @@ services:
             file: common.yaml
             service: odoo
         restart: unless-stopped
+        environment:
+            INITIAL_LANG: "$INITIAL_LANG"
         depends_on:
             - db
             - smtp


### PR DESCRIPTION
Using it in devel and test has the following problems:

- You tend to see merged languages in the UI when you develop in English but see it in another language.
- Almost all PhantomJS tests are subject to fail.

So let's stick to the standard en_US in those environments, and let only production get their default expected language.