### PR TITLE
[DEV] Support VSCode officially

### DIFF
--- a/.vscode/doodbasetup.py
+++ b/.vscode/doodbasetup.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+from configparser import ConfigParser
+from os import path
+from urllib.request import urlretrieve
+import os
+import shutil
+import sys
+
+try:
+    from compose.config.environment import env_vars_from_file
+except ImportError:
+    print(
+        "Execute `pip3 install docker-compose` to enable Python "
+        "version autoguessing in Doodba projects",
+        file=sys.stderr,
+    )
+
+PYLINT_CONFIGS = (
+    "maintainer-quality-tools/master/travis/cfg/travis_run_pylint_pr.cfg",
+    "maintainer-quality-tools/master/travis/cfg/travis_run_pylint.cfg",
+    "maintainer-quality-tools/master/travis/cfg/travis_run_pylint_beta.cfg",
+)
+CONFIGS = PYLINT_CONFIGS + (
+    "maintainer-quality-tools/master/travis/cfg/travis_run_flake8.cfg",
+    "pylint-odoo/master/pylint_odoo/examples/.jslintrc",
+)
+DEST = path.join(path.dirname(__file__), "doodba")
+ENV_FILE = path.join(DEST, "..", "..", ".env")
+env = env_vars_from_file(ENV_FILE)
+
+# Use the right Python version for current Doodba project
+version = env.get("ODOO_MINOR")
+if version in {"8.0", "9.0", "10.0"}:
+    executable = shutil.which("python2") or shutil.which("python")
+else:
+    executable = sys.executable
+try:
+    os.remove(path.join(DEST, "python"))
+except FileNotFoundError:
+    pass
+os.symlink(executable, path.join(DEST, "python"))
+
+# Download linter configs
+for config in CONFIGS:
+    urlretrieve(
+        "https://raw.githubusercontent.com/OCA/" + config,
+        path.join(DEST, path.basename(config)),
+    )
+
+# Produce merged pylint config
+baseparser = ConfigParser()
+baseparser.read(path.join(DEST, path.basename(PYLINT_CONFIGS[0])))
+for config in PYLINT_CONFIGS[1:]:
+    parser = ConfigParser()
+    parser.read(path.join(DEST, path.basename(config)))
+    baseparser["MESSAGES CONTROL"]["enable"] += \
+        "," + parser["MESSAGES CONTROL"]["enable"]
+# No duplicated commas
+baseparser["MESSAGES CONTROL"]["enable"] = \
+    baseparser["MESSAGES CONTROL"]["enable"].replace(",,", ",")
+# Add Doodba specific stuff
+baseparser["ODOOLINT"]["valid_odoo_versions"] = version
+with open(path.join(DEST, "doodba_pylint.cfg"), "w") as config:
+    baseparser.write(config)
+
+# Final reminder
+print("""
+Setup finished:
+
+- Configured to use {}
+- Linters configured for Odoo {}
+
+To have full Doodba VSCode support, remember to:
+
+- Install the recommended extensions
+- Install Python 2 and 3
+- Install eslint
+- Install pylint-odoo (both for Python 2 and 3)
+- Install flake8 (both for Python 2 and 3)
+
+Enjoy :)
+""".format(executable, version))

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,12 @@
+{
+    "recommendations": [
+        "dbaeumer.vscode-eslint",
+        "EditorConfig.editorconfig",
+        "lextudio.restructuredtext",
+        "mrorz.language-gettext",
+        "ms-python.python",
+        "PeterJausovec.vscode-docker",
+        "qub.qub-xml-vscode",
+        "robinbentley.sass-indented",
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Attach to running container",
+            "type": "python",
+            "request": "attach",
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceRoot}/odoo",
+                    "remoteRoot": "/opt/odoo"
+                }
+            ],
+            "port": 6899,
+            "host": "localhost"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+    "eslint.options": {
+        "configFile": ".vscode/doodba/.jslintrc",
+    },
+    "python.autoComplete.extraPaths": [
+        "${workspaceRoot}/odoo/custom/src/odoo",
+    ],
+    "python.linting.flake8Args": [
+        "--config=${workspaceRoot}/.vscode/doodba/travis_run_flake8.cfg",
+    ],
+    "python.linting.ignorePatterns": [
+        "${workspaceRoot}/odoo/custom/src/odoo",
+    ],
+    "python.linting.pylintArgs": [
+        "--init-hook=\"import sys;sys.path.append('${workspaceRoot}/odoo/custom/src/odoo')\"",
+        "--load-plugins=pylint_odoo",
+        "--rcfile='${workspaceRoot}/.vscode/doodba/doodba_pylint.cfg'",
+    ],
+    "python.pythonPath": "${workspaceRoot}/.vscode/doodba/python",
+    "search.useIgnoreFiles": false,
+    "search.followSymlinks": false,
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,123 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Set up VSCode development environment",
+            "type": "process",
+            "command": "python3",
+            "args": [
+                ".vscode/doodbasetup.py"
+            ],
+            "problemMatcher": [],
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "dedicated",
+                "showReuseMessage": false
+            },
+        },
+        {
+            "label": "Update git code",
+            "type": "shell",
+            "command": "docker-compose",
+            "args": [
+                "--file=setup-devel.yaml",
+                "run",
+                "--rm",
+                {
+                    "value": "-eUID=$UID",
+                    "quoting": "weak"
+                },
+                {
+                    "value": "-eGID=$(id -g $USER)",
+                    "quoting": "weak"
+                },
+                {
+                    "value": "-eUMASK=$(umask)",
+                    "quoting": "weak"
+                },
+                "odoo"
+            ],
+            "options": {
+                "shell": {
+                    "executable": "sh",
+                    "args": [
+                        "-c"
+                    ]
+                },
+                "cwd": "${workspaceRoot}"
+            },
+            "problemMatcher": [],
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "dedicated",
+                "showReuseMessage": false
+            },
+        },
+        {
+            "label": "Pull images",
+            "type": "process",
+            "command": "docker-compose",
+            "args": [
+                "pull"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+        },
+        {
+            "label": "Build images",
+            "type": "process",
+            "command": "docker-compose",
+            "args": [
+                "build",
+                "--pull"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+        },
+        {
+            "label": "Start project",
+            "type": "process",
+            "command": "docker-compose",
+            "args": [
+                "up",
+                "-d"
+            ],
+            "isBackground": true,
+            "problemMatcher": [],
+        },
+        {
+            "label": "Start project in debug mode",
+            "type": "process",
+            "command": "docker-compose",
+            "args": [
+                "up",
+                "-d"
+            ],
+            "options": {
+                "env": {
+                    "DOODBA_PTVSD_ENABLE": "1"
+                }
+            },
+            "isBackground": true,
+            "problemMatcher": [],
+        },
+        {
+            "label": "Restart Odoo containers",
+            "type": "process",
+            "command": "docker-compose",
+            "args": [
+                "restart",
+                "-t0",
+                "odoo",
+                "odoo_proxy"
+            ],
+            "problemMatcher": [],
+        },
+    ],
+}

--- a/devel.yaml
+++ b/devel.yaml
@@ -51,7 +51,7 @@ services:
             - odoo
             - --workers=0
             # XXX Odoo v8 has no `--dev` mode; Odoo v9 has no parameters
-            - --dev=reload,qweb,werkzeug,xml,wdb
+            - --dev=reload,qweb,werkzeug,xml
 
     db:
         extends:


### PR DESCRIPTION
This initial support is not very beautiful, but it works.

From now on, VSCode users will have custom tasks that will make Doodba development much easier for them. An important one is *Set up VSCode development environment*, which makes some magic:

- ESLint, Pylint and Flake8 get configured to use OCA's standards automatically.
- Python interpreted selected automatically.

There's also a task that boots Odoo in debugging mode (with ptvsd), and a debugger configuration that attaches to that local running container, so you have fully integrated debugging!

As such, the wdb debugger auto-post-mortem mode is disabled. It was cumbersome anyway, sometimes stopping processes without notice.