### PR TITLE
[DCK] Add pgadmin4 container in devel

### DIFF
--- a/devel.yaml
+++ b/devel.yaml
@@ -58,6 +58,17 @@ services:
             file: common.yaml
             service: db
 
+    pgadmin:
+        image: dpage/pgadmin4
+        depends_on:
+            - db
+        environment:
+            PGADMIN_DEFAULT_EMAIL: admin
+            PGADMIN_DEFAULT_PASSWORD: admin
+        networks: *public
+        ports:
+            - "127.0.0.1:5050:80"
+
     smtp:
         extends:
             file: common.yaml


### PR DESCRIPTION
From now on, you can review containerized postgres server by visiting http://localhost:5050 and using pgAdmin with credentials admin - admin.

Configure access to the Postgres server with:

- Host: db
- Port: 5432
- User: The `$DB_USER` from `.env`
- Password: The `$DB_PASSWORD` from `.env`