### PR TITLE
[IMP] Use the same scaffolding for QA instead of separate image

### DIFF
--- a/qa/.gitlab-ci.yml
+++ b/qa/.gitlab-ci.yml
@@ -1,0 +1,98 @@
+stages:
+  - build
+  - test
+
+variables: &globalvars
+    ODOO_REPO: "odoo/odoo"
+    ODOO_MINOR: "11.0"
+    REGISTRY_HOST: "user/image"
+    GIT_DEPTH: "3"
+    GIT_STRATEGY: none
+    GIT_HOST: "git-repo"
+    GIT_DOCKER_PROJECT_REPO: "doodba-scaffolding"
+    CI_IMAGE: "$REGISTRY_HOST/$CI_PROJECT_NAME-$ODOO_MINOR"
+    CI_TEST_IMAGE: "$REGISTRY_HOST/$CI_PROJECT_NAME-$ODOO_MINOR-test"
+    PGHOST: "localhost"
+    POSTGRES_DB: test
+    POSTGRES_USER: odoo
+    POSTGRES_PASSWORD: "odoopassword"
+    ADDON_CATEGORIES: "--private"
+
+before_script:
+    - eval "$(ssh-agent -s)"
+    - mkdir -p ~/.ssh
+    - chmod 700 ~/.ssh
+    - ssh-keyscan github.com >> ~/.ssh/known_hosts
+    - echo "$SSH_CONFIG" > ~/.ssh/config
+    - echo "$SSH_PRIVATE_KEY" | tr -d '\r' | ssh-add  - > /dev/null
+    - chmod 600 ~/.ssh/ -R
+    - echo $GCE_SERVICE_ACCOUNT_JSON > /service_account.json
+
+
+# Build docker image using dind / shell executor etc
+Build:
+ image: google/cloud-sdk:alpine
+ stage: build
+ variables:
+   <<: *globalvars
+   GIT_STRATEGY: clone
+ script:
+   - gcloud auth activate-service-account --key-file=/service_account.json
+   - git clone $GIT_HOST/$GIT_DOCKER_PROJECT_REPO.git -b ${ODOO_MINOR} --depth=1 /$CI_PROJECT_NAME
+   - cp $CI_PROJECT_DIR/* /$CI_PROJECT_NAME/src/private -R;
+   - gcloud builds submit --config /$CI_PROJECT_NAME/cloudbuild.yaml /$CI_PROJECT_NAME --substitutions _CI_IMAGE=$CI_IMAGE,_CI_TEST_IMAGE=$CI_TEST_IMAGE,_CI_PIPELINE_ID=$CI_PIPELINE_ID
+
+# Use gitlab service to help run the odoo image for testing
+Test Addons:
+  services:
+    - name: postgres:10.0-alpine
+  image: ${CI_TEST_IMAGE}:${CI_PIPELINE_ID}
+  stage: test
+  before_script: []
+  script:
+    # Execute entrypoint to wait for db to be ready and other things
+    - /opt/odoo/common/entrypoint
+    # Initialize the database and install all the repository modules
+    - addons init -i $ADDON_CATEGORIES
+    # Execute coverage tests on the initialized database
+    - qa_coverage
+    # Move coverage report
+    - mv /qa/artifacts/coverage .
+  artifacts:
+    paths:
+      - coverage
+    when: always
+  coverage: /TOTAL.* (\d+)%/
+
+Pylint Loose: &pylint
+  image: ${CI_TEST_IMAGE}:${CI_PIPELINE_ID}
+  stage: test
+  before_script: []
+  script:
+    - qa_pylint
+
+Pylint Strict:
+  <<: *pylint
+  variables:
+    LINT_MODE: "pr"
+  except:
+    - ^\d+\.\d+$
+
+Pylint Strict Warnings:
+  <<: *pylint
+  allow_failure: true
+  only:
+    - ^\d+\.\d+$
+
+Pylint Beta:
+  <<: *pylint
+  variables:
+    LINT_MODE: "beta"
+  allow_failure: true
+
+Flake8:
+  image: ${CI_TEST_IMAGE}:${CI_PIPELINE_ID}
+  stage: test
+  before_script: []
+  script:
+    - qa_flake8

--- a/qa/Dockerfile
+++ b/qa/Dockerfile
@@ -1,0 +1,34 @@
+ARG CI_IMAGE
+ARG CI_PIPELINE_ID
+FROM $CI_IMAGE:$CI_PIPELINE_ID
+
+USER root
+
+ENV ADDON_CATEGORIES="--private" \
+    CONTAINER_PREFIX="ci" \
+    LANG=C.UTF-8 \
+    LINT_DISABLE="manifest-required-author" \
+    LINT_ENABLE="" \
+    QA_VOLUME="" \
+    REPOS_FILE="odoo/custom/src/repos.yaml" \
+    SHARED_NETWORK=inverseproxy_shared \
+    VERBOSE=0
+
+RUN pip install --no-cache-dir coverage click flake8 pylint-odoo \
+        && npm install --loglevel error eslint \
+        && mkdir -p /qa/artifacts \
+        && chown -R 1000:1000 /qa/artifacts \
+        && chmod a=rwX /qa/artifacts \
+        && git clone --depth 1 https://github.com/OCA/maintainer-quality-tools.git /qa/mqt
+
+COPY --chown=root:1000 test-scripts /qa/insider
+
+WORKDIR /usr/local/bin
+
+RUN for f in $(ls /qa/insider); do ln -s /qa/insider/$f $f; done; sync
+
+USER odoo
+
+WORKDIR /opt/odoo
+
+ENTRYPOINT ["/bin/bash"]

--- a/qa/test-scripts/addons-install
+++ b/qa/test-scripts/addons-install
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+[ "$VERBOSE" -lt 1 ] || set -x
+
+# Check addons exist
+errorcode=0
+addons="$(addons list -i $ADDONS_EXTRA_ARGS $ADDON_CATEGORIES)" || errorcode=$?
+
+# If no addons are found, it's done
+[ "$errorcode" -eq 2 ] && exit 0 || [ "$errorcode" -eq 0 ]
+
+# Install all required addons
+addons init -x $ADDONS_EXTRA_ARGS $ADDON_CATEGORIES

--- a/qa/test-scripts/qa_coverage
+++ b/qa/test-scripts/qa_coverage
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+[ "$VERBOSE" -lt 1 ] || set -x
+
+# Check addons exist
+returncode=0
+addons="$(addons list -i $ADDONS_EXTRA_ARGS $ADDON_CATEGORIES)" || returncode=$?
+
+# If no addons are found, it's done
+[ "$returncode" -eq 2 ] && exit 0 || [ "$returncode" -eq 0 ]
+
+# Test addons and report coverage
+odoo="$(realpath "$(which odoo)")"
+cd
+coverage run \
+    --source "$(addons list -if $ADDONS_EXTRA_ARGS $ADDON_CATEGORIES)" \
+    --omit '*/__openerp__.py,*/__manifest__.py,/opt/odoo/custom/src/*/*/__init__.py' \
+    "$odoo" -d $PGDATABASE --stop-after-init --workers 0 --test-enable -u "$addons"
+returncode=$?
+coverage report --skip-covered
+mkdir -p /qa/artifacts/coverage
+coverage html --skip-covered --directory /qa/artifacts/coverage
+exit $returncode

--- a/qa/test-scripts/qa_flake8
+++ b/qa/test-scripts/qa_flake8
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+[ "$VERBOSE" -lt 1 ] || set -x
+
+# Check addons exist
+errorcode=0
+addons="$(addons list -ifs ' ' $ADDONS_EXTRA_ARGS $ADDON_CATEGORIES)" || errorcode=$?
+
+# If no addons are found, it's done
+[ "$errorcode" -eq 2 ] && exit 0 || [ "$errorcode" -eq 0 ]
+
+cd /qa/mqt
+export PATH="$PATH:/qa/mqt/travis"
+
+# Lint
+export INCLUDE_LINT="$addons"
+test_flake8

--- a/qa/test-scripts/qa_pylint
+++ b/qa/test-scripts/qa_pylint
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -e
+[ "$VERBOSE" -lt 1 ] || set -x
+
+# Check addons exist
+errorcode=0
+addons="$(addons list -ifs ' ' $ADDONS_EXTRA_ARGS $ADDON_CATEGORIES)" || errorcode=$?
+
+# If no addons are found, it's done
+[ "$errorcode" -eq 2 ] && exit 0 || [ "$errorcode" -eq 0 ]
+
+# Configure pylint
+if [ -n "$LINT_ENABLE" ]; then
+    enable="--enable $LINT_ENABLE"
+fi
+if [ -n "$LINT_DISABLE" ]; then
+    disable="--disable $LINT_DISABLE"
+fi
+
+PYLINT_CONFIG_FILE="travis_run_pylint"
+PYLINT_CONFIG_FILE+=${LINT_MODE+_$LINT_MODE}.cfg
+
+# Lint
+# TODO Use MQT's `test_pylint` directly when it becomes more reusable
+code=0
+for addon in $addons; do
+    pylint --load-plugins pylint_odoo \
+        --rcfile /qa/mqt/travis/cfg/$PYLINT_CONFIG_FILE \
+        --valid_odoo_versions=$ODOO_VERSION \
+        $enable $disable $addon || code=$?
+done
+
+exit $code


### PR DESCRIPTION
This is basically an unpolished POC to merge the purpose of the doobda-scaffolding and doodba-qa projects.

I have successfully implemented this approach in my environment using an external image building service.

The simplified workflow is:
Production image is built -> Test image is built from the production image (added dependencies for testing) -> tests are made -> production image is deployed to production.

If you find interest in this approach I can improve / fix required aspects to get it merged, just wanted to see if it peaks your interest first.