### PR TITLE
[CI] Enable CI in official doodba-scaffolding repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,47 @@
+sudo: required
+
+language: python
+
+python:
+  - "3.6"
+
+services:
+  - docker
+
+git:
+  depth: 1
+
+branches:
+  only:
+    - master
+
+env:
+  global:
+  matrix:
+    - ODOO_MAJOR=8 ODOO_MINOR=8.0
+    - ODOO_MAJOR=9 ODOO_MINOR=9.0
+    - ODOO_MAJOR=10 ODOO_MINOR=10.0
+    - ODOO_MAJOR=11 ODOO_MINOR=11.0
+    - ODOO_MAJOR=12 ODOO_MINOR=12.0
+
+before_install:
+  - sudo apt-get -y -o Dpkg::Options::=--force-confnew install docker-ce
+
+script:
+  - qa="docker container run
+    --rm -it --privileged -v $PWD:$PWD:z
+    -v /var/run/docker.sock:/var/run/docker.sock:z
+    -w $PWD
+    -e ADDON_CATEGORIES=-p
+    -e COMPOSE_FILE=test.yaml
+    -e ODOO_MAJOR=$ODOO_MAJOR
+    -e ODOO_MINOR=$ODOO_MINOR
+    tecnativa/doodba-qa:no-qa-volume"
+  - $qa networks-autocreate
+  - $qa build
+  - $qa closed-prs
+  - $qa flake8
+  - $qa pylint
+  - $qa addons-install
+  - $qa coverage
+  - $qa shutdown


### PR DESCRIPTION
This follows the QA redesign explained in https://github.com/Tecnativa/doodba-qa/issues/8.