### PR TITLE
[DCK] Increase worker memory by default

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -29,6 +29,8 @@ services:
             POSTGRES_PASSWORD: "$DB_PASSWORD"
         volumes:
             - db:/var/lib/postgresql/data:z
+        command:
+            - -cwork_mem=32MB
 
     smtpfake:
         image: mailhog/mailhog


### PR DESCRIPTION
HACK https://github.com/odoo/odoo/issues/30350

Odoo's ORM just takes forever in some queries if your worker has not enough memory.

To avoid hitting that problem, let's configure a big memory default for Doodba users.