### PR TITLE
[DCK] Avoid extra "odoo" database

### DIFF
--- a/devel.yaml
+++ b/devel.yaml
@@ -30,7 +30,7 @@ services:
         environment:
             ADMIN_PASSWORD: admin
             PTVSD_ENABLE: "${DOODBA_PTVSD_ENABLE:-0}"
-            PGDATABASE: devel
+            PGDATABASE: &dbname devel
             PYTHONOPTIMIZE: ""
             SMTP_PORT: "1025"
             # You want demo data for development
@@ -57,6 +57,8 @@ services:
         extends:
             file: common.yaml
             service: db
+        environment:
+            POSTGRES_DB: *dbname
 
     smtp:
         extends:

--- a/prod.yaml
+++ b/prod.yaml
@@ -7,6 +7,7 @@ services:
         restart: unless-stopped
         environment:
             INITIAL_LANG: "$INITIAL_LANG"
+            PGDATABASE: &dbname prod
         depends_on:
             - db
             - smtp
@@ -37,6 +38,8 @@ services:
         extends:
             file: common.yaml
             service: db
+        environment:
+            POSTGRES_DB: *dbname
         restart: unless-stopped
 
     smtp:

--- a/test.yaml
+++ b/test.yaml
@@ -5,7 +5,7 @@ services:
             file: common.yaml
             service: odoo
         environment:
-            PGDATABASE: test
+            PGDATABASE: &dbname test
             # You may want demo data for testing
             WITHOUT_DEMO: "false"
             SMTP_PORT: "1025"
@@ -42,6 +42,8 @@ services:
         extends:
             file: common.yaml
             service: db
+        environment:
+            POSTGRES_DB: *dbname
         restart: unless-stopped
 
     smtp:


### PR DESCRIPTION

If the Postgres container doesn't include a `$POSTGRES_DB` it will default to its `$POSTGRES_USER`, which is `odoo` in most cases.

This produces that in recent versions of the scaffolding, when booting Odoo, the user is prompted with 2 databases in the list: "odoo" and one of "devel", "test" or "prod", depending on the current environment.

By setting the same value in both `odoo` and `db` containers, we avoid such problem.