### PR TITLE
[DCK] Test DB name will be "prod" by default instead of "test"

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -8,8 +8,9 @@ services:
                 ODOO_VERSION: $ODOO_MINOR
         environment:
             ADMIN_PASSWORD: "$ODOO_ADMIN_PASSWORD"
-            PGPASSWORD: "$DB_PASSWORD"
-            PGUSER: "$DB_USER"
+            PGDATABASE: &dbname prod
+            PGPASSWORD: &dbpass "$DB_PASSWORD"
+            PGUSER: &dbuser "$DB_USER"
             DB_FILTER: "$DB_FILTER"
             PROXY_MODE: "$ODOO_PROXY_MODE"
         tty: true
@@ -25,8 +26,9 @@ services:
     db:
         image: postgres:${DB_VERSION}-alpine
         environment:
-            POSTGRES_USER: "$DB_USER"
-            POSTGRES_PASSWORD: "$DB_PASSWORD"
+            POSTGRES_DB: *dbname
+            POSTGRES_PASSWORD: *dbpass
+            POSTGRES_USER: *dbuser
         volumes:
             - db:/var/lib/postgresql/data:z
         command:
@@ -59,9 +61,9 @@ services:
             EMAIL_FROM: "$BACKUP_EMAIL_FROM"
             EMAIL_TO: "$BACKUP_EMAIL_TO"
             PASSPHRASE: "$BACKUP_ENCRYPT_KEY"
-            PGDATABASE: prod
-            PGPASSWORD: "$DB_PASSWORD"
-            PGUSER: "$DB_USER"
+            PGDATABASE: *dbname
+            PGPASSWORD: *dbpass
+            PGUSER: *dbuser
             SMTP_HOST: smtplocal
         volumes:
             - backup_cache:/root:z

--- a/devel.yaml
+++ b/devel.yaml
@@ -29,6 +29,7 @@ services:
                 COMPILE: "false"
         environment:
             ADMIN_PASSWORD: admin
+            DOODBA_ENVIRONMENT: devel
             PTVSD_ENABLE: "${DOODBA_PTVSD_ENABLE:-0}"
             PGDATABASE: &dbname devel
             PYTHONOPTIMIZE: ""

--- a/prod.yaml
+++ b/prod.yaml
@@ -6,8 +6,8 @@ services:
             service: odoo
         restart: unless-stopped
         environment:
+            DOODBA_ENVIRONMENT: prod
             INITIAL_LANG: "$INITIAL_LANG"
-            PGDATABASE: &dbname prod
             SMTP_SERVER: smtplocal
         depends_on:
             - db
@@ -39,8 +39,6 @@ services:
         extends:
             file: common.yaml
             service: db
-        environment:
-            POSTGRES_DB: *dbname
         restart: unless-stopped
 
     smtp:

--- a/test.yaml
+++ b/test.yaml
@@ -5,7 +5,7 @@ services:
             file: common.yaml
             service: odoo
         environment:
-            PGDATABASE: &dbname test
+            DOODBA_ENVIRONMENT: test
             # You may want demo data for testing
             WITHOUT_DEMO: "false"
             SMTP_PORT: "1025"
@@ -43,8 +43,6 @@ services:
         extends:
             file: common.yaml
             service: db
-        environment:
-            POSTGRES_DB: *dbname
         restart: unless-stopped
 
     smtp:


### PR DESCRIPTION
From this change onwards, test environments will have their default databases called "prod", instead of "test" by default.

This will ease the process of transfering data between environments, such as what happens when using the test environment for staging or migrating a production deployment.

In case you were using `ONLY` with `PGDATABASE`  in  `addons.yaml` to filter some addons, to still let you have a way to know the current environment, a new `$DOODBA_ENVIRONMENT` variable is added, with each environment name hardcoded in it. Example:

```yaml
# Common addons
---
# Enable web ribbon in non-prod environments
ONLY:
  DOODBA_ENVIRONMENT:
  - devel
  - test
web:
- web_environment_ribbon
```

Read here the risk of this patch: https://github.com/Tecnativa/doodba/issues/67#issuecomment-458881087