### PR TITLE
[DCK] Make the "odoo" package importable anywhere

### DIFF
--- a/devel.yaml
+++ b/devel.yaml
@@ -33,6 +33,7 @@ services:
             PTVSD_ENABLE: "${DOODBA_PTVSD_ENABLE:-0}"
             PGDATABASE: &dbname devel
             PYTHONOPTIMIZE: ""
+            PYTHONPATH: /opt/odoo/custom/src/odoo
             SMTP_PORT: "1025"
             # You want demo data for development
             WITHOUT_DEMO: "false"


### PR DESCRIPTION

This is [the requirement to use click-odoo][1]. It is fulfilled automatically in test and prod environments, where odoo is pip-installed; but for devel, the easiest way is to add the odoo path to the `$PYTHONPATH`. This way, you can test your `odoo-click` scripts in devel too.

[1]: https://github.com/acsone/click-odoo#quick-start