### PR TITLE
[DCK] Allow to choose demo data with $DOODBA_WITHOUT_DEMO

### DIFF
--- a/devel.yaml
+++ b/devel.yaml
@@ -35,8 +35,8 @@ services:
             PYTHONOPTIMIZE: ""
             PYTHONPATH: /opt/odoo/custom/src/odoo
             SMTP_PORT: "1025"
-            # You want demo data for development
-            WITHOUT_DEMO: "false"
+            # To avoid installing demo data export DOODBA_WITHOUT_DEMO=all
+            WITHOUT_DEMO: "${DOODBA_WITHOUT_DEMO-false}"
         volumes:
             - ./odoo/custom:/opt/odoo/custom:ro,z
             - ./odoo/auto/addons:/opt/odoo/auto/addons:rw,z

--- a/test.yaml
+++ b/test.yaml
@@ -6,8 +6,8 @@ services:
             service: odoo
         environment:
             DOODBA_ENVIRONMENT: "${DOODBA_ENVIRONMENT-test}"
-            # You may want demo data for testing
-            WITHOUT_DEMO: "false"
+            # To install demo data export DOODBA_WITHOUT_DEMO=false
+            WITHOUT_DEMO: "${DOODBA_WITHOUT_DEMO-all}"
             SMTP_PORT: "1025"
             SMTP_SERVER: smtplocal
         restart: unless-stopped


### PR DESCRIPTION
The `test.yaml` file can be used for CI, yes, but it can be used also for _migrations_ and _staging_ instances. In those environments, having demo data can lead to wrong data and user confusion, so it's better to disable it.

Now, **by default, `test.yaml` will not install demo data** unless run under `env DOODBA_WITHOUT_DEMO=false`. This is a behavioral change based on the assumption that it is easier for you to add that variable to CI (which always is automated) than to staging or migrations (which might or not be automated).

To make it more consistent, in `devel.yaml` you are also able to use that same variable to choose if you want or not demo data. However, in this case, we default to have demo data, since it is almost a need for development.

In `prod.yaml` this variable is not supported because it should never have demo data.