### PR TITLE
[DCK] Remove outdated samples

### DIFF
--- a/.vscode/doodba.code-snippets
+++ b/.vscode/doodba.code-snippets
@@ -1,0 +1,20 @@
+// See spec in https://code.visualstudio.com/docs/editor/userdefinedsnippets
+{
+    // See https://github.com/Tecnativa/doodba#optodoocustomsrcreposyaml
+    "Git aggregator repo": {
+        "prefix": "repo",
+        "scope": "yaml",
+        "body": [
+            "${10:repo-name}:",
+            "\tdefaults:",
+            "\t\tdepth: \\$DEPTH_MERGE",
+            "\tremotes:",
+            "\t\t${40:origin}: ${30:https://github.com/${20:OCA}/${10}.git}",
+            "\ttarget: ${40} \\$ODOO_VERSION",
+            "\tmerges:",
+            "\t\t- ${40} \\$ODOO_VERSION",
+            "\t\t- ${40} refs/pull/${50:1234}/head",
+        ],
+        "description": "For Loop"
+    }
+}

--- a/odoo/custom/dependencies/pip.txt
+++ b/odoo/custom/dependencies/pip.txt
@@ -1,6 +1,3 @@
-checksumdir
 git+https://github.com/OCA/openupgradelib.git@master
 unicodecsv
 unidecode
-requests
-xlsxwriter

--- a/odoo/custom/src/repos.yaml
+++ b/odoo/custom/src/repos.yaml
@@ -1,4 +1,5 @@
 # Odoo is always required
+# See https://github.com/Tecnativa/doodba#optodoocustomsrcreposyaml
 ./odoo:
     defaults:
         # Shallow repositories ($DEPTH_DEFAULT=1) are faster & thinner
@@ -15,14 +16,3 @@
         - ocb $ODOO_VERSION
         # Example of a merge of the PR with the number <PR>
         # - oca refs/pull/<PR>/head
-
-# Example of an OCA repository
-./l10n-spain:
-    defaults:
-        depth: $DEPTH_DEFAULT
-    remotes:
-        oca: https://github.com/OCA/l10n-spain.git
-    target:
-        oca $ODOO_VERSION
-    merges:
-        - oca $ODOO_VERSION


### PR DESCRIPTION

- `l10n-spain` was never a good sample, since only Spanish projects would have it. Since https://github.com/Tecnativa/doodba/pull/86 it's simply not needed in most cases. Devs can check the docs to know the structure. Thus, it can be removed from here.
- `checksumdir` is not used anymore in `module_auto_update` since https://github.com/OCA/server-tools/pull/1190.
- `xlsxwriter` is included in Odoo 10+.
- `requests` is included in Odoo 8+.