### PR TITLE
[DCK] Switch to tecnativa/postgres-autoconf image

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -22,7 +22,7 @@ services:
             traefik.port: "8069"
 
     db:
-        image: postgres:${DB_VERSION}-alpine
+        image: tecnativa/postgres-autoconf:${DB_VERSION}-alpine
         environment:
             POSTGRES_DB: *dbname
             POSTGRES_USER: *dbuser


### PR DESCRIPTION

The official postgres image is not easy to autoconfigure. Let's switch over to a customized version, based on the official one, that will let us better autoconfiguration.

For most projects, this will be a transparent switch.