### PR TITLE
[DCK] Enable database manager in devel

### DIFF
--- a/devel.yaml
+++ b/devel.yaml
@@ -29,6 +29,7 @@ services:
                 COMPILE: "false"
         environment:
             DOODBA_ENVIRONMENT: "${DOODBA_ENVIRONMENT-devel}"
+            LIST_DB: "true"
             PTVSD_ENABLE: "${DOODBA_PTVSD_ENABLE:-0}"
             PGDATABASE: &dbname devel
             PYTHONOPTIMIZE: ""


### PR DESCRIPTION
As explained in https://github.com/Tecnativa/doodba/issues/211#issuecomment-475863340, database manager is very useful for development, without impacting security. Enabled by default. It also serves as an example on how to enable it.