### PR TITLE
[DCK] Restore proxy mode security warning comment

### DIFF
--- a/.env
+++ b/.env
@@ -5,6 +5,7 @@ ODOO_MINOR=11.0
 INITIAL_LANG=
 ODOO_IMAGE=docker.io/myuser/myproject-odoo
 
+# Critical for security!!!
 ODOO_PROXY_MODE=true
 
 # Domains


### PR DESCRIPTION
Partially reverts 02574d9a33ef4178550fbabe865bbc2bcc6c7652.

- Removed the `XXX` from the comment, because it will not require manual intervention in most cases, where test and prod should always be behind a proxy.
- Restored the security warning, because there's still a security concern with this setting: enabling proxy mode when odoo is not behind a proxy opens an attack vector.