### PR TITLE
[DCK] Add mail hostname to odoo container

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -11,6 +11,7 @@ services:
             PGUSER: &dbuser "$DB_USER"
             DB_FILTER: "$DB_FILTER"
             PROXY_MODE: "$ODOO_PROXY_MODE"
+        hostname: "$SMTP_REAL_NON_CANONICAL_DEFAULT"
         tty: true
         volumes:
             - filestore:/var/lib/odoo:z


### PR DESCRIPTION
It turns out that [Odoo, by default, uses the local hostname as the host part in the autogenerated `Message-Id` for outgoing emails][1].

[Official Mailgun documentation][2] says, among best practices for avoiding SPAM filters:

>  Message IDs that are formed incorrectly (without brackets <> and **with wrong domain after @**) can make Gmail think you are a spammer.

So, here I set the odoo container's hostname to the same value as the default domain selected for outgoing emails, from the real SMTP settings.

It should lower SPAM rating. It's not a silver bullet for those filters, but should help.

[1]: https://github.com/odoo/odoo/blob/7e9a13a64d71afc7d46d616824daf86938c9ee1a/odoo/tools/mail.py#L440
[2]: https://documentation.mailgun.com/en/latest/best_practices.html#email-content