### PR TITLE
[DCK] Increase postgres work_mem by env

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -27,10 +27,10 @@ services:
         environment:
             POSTGRES_DB: *dbname
             POSTGRES_USER: *dbuser
+            CONF_EXTRA: |
+                work_mem = 32MB
         volumes:
             - db:/var/lib/postgresql/data:z
-        command:
-            - -cwork_mem=32MB
 
     smtpfake:
         image: mailhog/mailhog


### PR DESCRIPTION

Default values should have lower priority, and the variable has lower priority than the command flags, so I change it here.

This change benefits from the new `tecnativa/postgres-autoconf` image introduced in 3d2728ba477ce553c0288e3273b89fa3766a3e06, which allows usage of `CONF_EXTRA` env var. To understand why this is a good default value, see 09323c859fd15bca1975f94659af5cfc6faac044.