### PR TITLE
[DCK] Odoo is no longer required

### DIFF
--- a/odoo/custom/src/repos.yaml
+++ b/odoo/custom/src/repos.yaml
@@ -1,4 +1,3 @@
-# Odoo is always required
 # See https://github.com/Tecnativa/doodba#optodoocustomsrcreposyaml
 ./odoo:
     defaults:


### PR DESCRIPTION
Since https://github.com/Tecnativa/doodba/pull/86, no addons or repos are required. This comment is an old true that is today a lie, so it's better away from here.