### PR TITLE
[DCK] Increase SHM size for Postgres

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -1,4 +1,4 @@
-version: "2.1"
+version: "2.4"
 services:
     odoo:
         image: $ODOO_IMAGE:$ODOO_MINOR
@@ -24,6 +24,7 @@ services:
 
     db:
         image: tecnativa/postgres-autoconf:${DB_VERSION}-alpine
+        shm_size: 512mb
         environment:
             POSTGRES_DB: *dbname
             POSTGRES_USER: *dbuser

--- a/devel.yaml
+++ b/devel.yaml
@@ -1,4 +1,4 @@
-version: "2.1"
+version: "2.4"
 
 services:
     odoo_proxy:

--- a/prod.yaml
+++ b/prod.yaml
@@ -1,4 +1,4 @@
-version: "2.1"
+version: "2.4"
 services:
     odoo:
         extends:

--- a/setup-devel.yaml
+++ b/setup-devel.yaml
@@ -7,7 +7,7 @@
 #
 #   git clean -ffd
 
-version: "2.1"
+version: "2.4"
 
 services:
     odoo:

--- a/test.yaml
+++ b/test.yaml
@@ -1,4 +1,4 @@
-version: "2.1"
+version: "2.4"
 services:
     odoo:
         extends:


### PR DESCRIPTION

This was added to the official image docs in https://github.com/docker-library/docs/pull/1331 and Odoo is heavy on Postgres, so we add it as a default value.

This will prevent unexpected failures on big transactions, such as migrations.