### PR TITLE
[DCK] Disable some limits for devel

### DIFF
--- a/devel.yaml
+++ b/devel.yaml
@@ -51,6 +51,9 @@ services:
             - wdb
         command:
             - odoo
+            - --limit-memory-soft=0
+            - --limit-time-real-cron=0
+            - --limit-time-real=0
             - --workers=0
             # XXX Odoo v8 has no `--dev` mode; Odoo v9 has no parameters
             - --dev=reload,qweb,werkzeug,xml


### PR DESCRIPTION

In Odoo v12, the threaded mode (a.k.a. `--workers=0`), which works best for development and unit testing, [started processing some limits from the config][1].

It's very likely that your development environment gets hitting those limits, no matter if you configured it for production under `conf.d` folder, or if you are using the default values. For example, if you're debugging, the debugger might add extra memory footprint, and it probably hit the execution timeout.

What I'm doing here is basically to disable those limits for development. This should make your dev life happier, out of the box.

For older Odoo versions, these limits were being ignored anyways, so it shouldn't harm.

[1]: https://github.com/odoo/odoo/blob/086b9ad879664448d8a4c9102b2cf158def04444/odoo/service/server.py#L338-L368