### PR TITLE
[FIX] pass defaults for UID and GID during checkout with setup-devel

### DIFF
--- a/setup-devel.yaml
+++ b/setup-devel.yaml
@@ -29,8 +29,8 @@ services:
         environment:
             DEPTH_DEFAULT: 100
             # XXX Export these variables before running setup to own the files
-            UID: "$UID"
-            GID: "$GID"
+            UID: "${UID:-1000}"
+            GID: "${GID:-1000}"
             UMASK: "$UMASK"
         user: root
         entrypoint: autoaggregate


### PR DESCRIPTION
Pass the same default values to setup-devel.yaml as in https://github.com/Tecnativa/doodba-scaffolding/blob/762644676564363d2c16a2bb4d1ad58ece9086e2/common.yaml#L9 when running.

This prevents https://github.com/Tecnativa/doodba/blob/master/bin/autoaggregate#L20 from using -1 for gid and uid and therefore skipping the chown after gitaggregate https://github.com/Tecnativa/doodba/blob/master/bin/autoaggregate#L50 which causes the checked out sources belonging to root.

This changes the default user everything checked out (if invoked without exported UID) belongs to from root to odoo (or uid=1000). In case someone wants to checkout the source for root, they have to run setup-devel as root with exported UID.
