### PR TITLE
[DCK] Support mailhog auth

### DIFF
--- a/test.yaml
+++ b/test.yaml
@@ -56,6 +56,13 @@ services:
             traefik.frontend.passHostHeader: "true"
             traefik.port: "8025"
             traefik.frontend.rule: "Host:${DOMAIN_TEST};PathPrefixStrip:/smtpfake/"
+        volumes:
+            - "smtpconf:/etc/mailhog:ro,z"
+        entrypoint: [sh, -c]
+        command:
+            - test -r /etc/mailhog/auth &&
+              export MH_AUTH_FILE=/etc/mailhog/auth;
+              exec MailHog
 
 networks:
     default:
@@ -72,3 +79,4 @@ networks:
 volumes:
     filestore:
     db:
+    smtpconf:


### PR DESCRIPTION

A new security measure for test environments is the possibility to require authentication for reading outgoing emails.

This is only implemented in `test.yaml`, which is the only public-facing environment that uses MailHog.

It uses now `/etc/mailhog/auth` as auth file in case it is present and readable at boot.

To fill that file:

```bash
docker-compose up --no-start
```

That command should tell you something like `Creating volume "myproject-smtpconf"`. Use that volume name as `$volume` and then:

```bash
docker container run --rm -it --uid 1000 -v $volume:/smtpconf --entrypoint= mailhog/mailhog vi /smtpconf/auth
```

There you can write your conf file and exit (as long as you know how to exit from vi).

After that, you can `docker-compose restart smtp` and get it working. You'll have to use a user and password to get access to mailhog.

Docs on MailHog's feature: https://github.com/mailhog/MailHog/blob/master/docs/Auth.md