### PR TITLE
[DCK] Modify real time limits in devel

### DIFF
--- a/devel.yaml
+++ b/devel.yaml
@@ -52,8 +52,8 @@ services:
         command:
             - odoo
             - --limit-memory-soft=0
-            - --limit-time-real-cron=0
-            - --limit-time-real=0
+            - --limit-time-real-cron=9999999
+            - --limit-time-real=9999999
             - --workers=0
             # XXX Odoo v8 has no `--dev` mode; Odoo v9 has no parameters
             - --dev=reload,qweb,werkzeug,xml


### PR DESCRIPTION

If you have to set up `--workers=4` in development to do some workers-specific work, the limits I'm changing have a different meaning if set as `0`, and that can be tricky to debug.

To avoid this problem, we just set a crazily high limit, which will work the same with threads and workers. Less surprises = more productivity!