### PR TITLE
[DCK] Support default from address

### DIFF
--- a/.env
+++ b/.env
@@ -18,6 +18,7 @@ DB_USER=odoo
 DB_FILTER=.*
 
 # Real SMTP relay
+SMTP_DEFAULT_FROM=postmaster@example.com
 SMTP_REAL_MAILNAME=example.com
 SMTP_REAL_RELAY_HOST=smtp.example.com
 SMTP_REAL_RELAY_PORT=587

--- a/common.yaml
+++ b/common.yaml
@@ -9,6 +9,7 @@ services:
                 UID: "${UID:-1000}"
                 GID: "${GID:-1000}"
         environment:
+            EMAIL_FROM: "$SMTP_DEFAULT_FROM"
             PGDATABASE: &dbname prod
             PGUSER: &dbuser "$DB_USER"
             DB_FILTER: "$DB_FILTER"


### PR DESCRIPTION

Just like https://github.com/odoo/odoo/pull/36837 introduces this feature per database, here we're going to add support for it in Doodba directly, via config file, as it is currently supported in Odoo.

You should fill this new env variable with the address that should be used as a default sender address in case the mail template doesn't supply one, which is a not-so-uncommon case.

Usually it should match your `mail.catchall.alias@mail.catchall.domain` combination, or the same value as for `$SMTP_REAL_RELAY_USER`, but it could be any other.

@Tecnativa TT19448