### PR TITLE
[DCK] Remove default value for SMTP_DEFAULT_FROM

### DIFF
--- a/.env
+++ b/.env
@@ -18,7 +18,7 @@ DB_USER=odoo
 DB_FILTER=.*
 
 # Real SMTP relay
-SMTP_DEFAULT_FROM=postmaster@example.com
+SMTP_DEFAULT_FROM=
 SMTP_REAL_MAILNAME=example.com
 SMTP_REAL_RELAY_HOST=smtp.example.com
 SMTP_REAL_RELAY_PORT=587


### PR DESCRIPTION

As discussed in #43, defaulting to an empty value should let most users update flawlessly their scaffoldings, as that would retain the same behavior as before.

Still if you want to use the feature, put a value as explained in #43.

@Tecnativa TT19448