### PR TITLE
[VSCODE] Add restructuredtext.confPath setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,7 @@
     ],
     "python.linting.pylintEnabled": true,
     "python.pythonPath": "${workspaceRoot}/.vscode/doodba/python",
+    "restructuredtext.confPath": "",
     "search.useIgnoreFiles": false,
     "search.followSymlinks": false,
 }


### PR DESCRIPTION

Due to https://github.com/vscode-restructuredtext/vscode-restructuredtext/issues/107, which was closed but still happens, this line keeps on appearing in the project config.

It is annoying to encounter it every now and then in the git history, so I'm just adding it here to force it not disturb us anymore.