### PR TITLE
[VSCODE] Add doodba-devel.code-workspace file automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,10 @@ docker-compose.yml
 **.egg-info
 **.orig
 
-# Editor garbage folders
+# User-specific or editor-specific development files and settings
 .vscode
+doodba-devel.code-workspace
+src
 
 # Project-specific docker configurations
 .docker

--- a/src
+++ b/src
@@ -1,1 +1,0 @@
-./odoo/custom/src/


### PR DESCRIPTION

After this patch, the next time you execute the VSCode setup task, it will scan your git subfolders inside `odoo/custom/src/addons` and it will configure them as top-level folders in a VSCode workspace file called `doodba-devel.code-workspace`.

After you do it, the next time you open this folder, VSCode will find automatically this workspace file and ask you to open it. If you open it, it will enable full git support in all subrepos.

The top folder will be added last as a workaround for https://github.com/microsoft/vscode/issues/37947.

Since all repo folders are now one click away, I'm removing the `src` symlink.