### PR TITLE
[VSCODE] Name workspace after folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ docker-compose.yml
 
 # User-specific or editor-specific development files and settings
 .vscode
-doodba-devel.code-workspace
+doodba.*.code-workspace
 src
 
 # Project-specific docker configurations

--- a/.vscode/doodbasetup.py
+++ b/.vscode/doodbasetup.py
@@ -29,6 +29,7 @@ CONFIGS = PYLINT_CONFIGS + (
 DEST = path.join(path.dirname(__file__), "doodba")
 ROOT = path.abspath(path.join(DEST, "..", ".."))
 ENV_FILE = path.join(ROOT, ".env")
+SCAFFOLDING_NAME = path.basename(path.abspath(ROOT))
 env = env_vars_from_file(ENV_FILE)
 
 # Use the right Python version for current Doodba project
@@ -42,6 +43,12 @@ try:
 except FileNotFoundError:
     pass
 os.symlink(executable, path.join(DEST, "python"))
+
+# Enable development environment by default
+try:
+    os.symlink("devel.yaml", path.join(ROOT, "docker-compose.yml"), True)
+except FileExistsError:
+    pass
 
 # Download linter configs
 for config in CONFIGS:
@@ -67,7 +74,7 @@ with open(path.join(DEST, "doodba_pylint.cfg"), "w") as config:
     baseparser.write(config)
 
 # Produce VSCode workspace
-WORKSPACE = path.join(ROOT, "doodba-devel.code-workspace")
+WORKSPACE = path.join(ROOT, "doodba.%s.code-workspace" % SCAFFOLDING_NAME)
 try:
     with open(WORKSPACE) as fp:
         workspace_config = json.load(fp)


### PR DESCRIPTION

Without this patch, after creating many workspaces across many scaffoldings, a problem happens: all of them are named the same. That makes it visually more difficult to find them in the recent projects quick opener.

To fix this problem, the generated file will be named like `doodba.$(basename $(absname .)).code-workspace`, so it's easier to find.

As a counterpart, if you already had the `doodba-devel.code-workspace` created in your scaffolding, it will no longer be git-ignored after you update the scaffolding. That's on purpose for you to remember to delete it and create the new one.