### PR TITLE
[FIX] Explicit paths in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
 # Ignore all src directories except private and files with a dot
-odoo/auto
-odoo/custom/src/*
-!odoo/custom/src/private
-!odoo/custom/src/*.*
+/odoo/auto
+/odoo/custom/src/*
+!/odoo/custom/src/private
+!/odoo/custom/src/*.*
 
 # Ignore docker-compose.yml by default, to allow easy defaults per clone
-docker-compose.yml
+/docker-compose.yml
 
 # Compiled formats, cache, temporary files, git garbage
 **.~
@@ -15,9 +15,9 @@ docker-compose.yml
 **.orig
 
 # User-specific or editor-specific development files and settings
-.vscode
-doodba.*.code-workspace
-src
+/.vscode
+/doodba.*.code-workspace
+/src
 
 # Project-specific docker configurations
-.docker
+/.docker


### PR DESCRIPTION

According to [git docs][1]:

> If there is a separator at the beginning or middle (or both) of the pattern, then the pattern is relative to the directory level of the particular `.gitignore` file itself. Otherwise the pattern may also match at any level below the `.gitignore` level.

That's why since 682755f4f173f6a7fe446180563b46c39b3a075d no file under `odoo/custom/src` was auto-tracked by git (`src` pattern had no separators, so it applied at any level in the code tree).

Also if you created a `.docker`, `doodba.*.code-workspace`, `.vscode` or `docker-compose.yml` file outside of the scaffolding root, those were excluded too.

Now, all paths that are expected to depend on their position in the scaffolding are prefixed with `/` to avoid surprises when ignoring files.

[1]: https://git-scm.com/docs/gitignore#_pattern_format