### PR TITLE
[DCK] Official wdb image, fix stop signal

### DIFF
--- a/devel.yaml
+++ b/devel.yaml
@@ -75,10 +75,12 @@ services:
             - "127.0.0.1:8025:8025"
 
     wdb:
-        image: yajo/wdb-server
+        image: kozea/wdb
         networks: *public
         ports:
             - "127.0.0.1:1984:1984"
+        # HACK https://github.com/Kozea/wdb/issues/136
+        stop_signal: KILL
 
     # Whitelist outgoing traffic for tests, reports, etc.
     cdnjs_cloudflare_proxy:


### PR DESCRIPTION
Nowadays wdb has an official image which is up to date, so there's no need to use my own.

Also I added a workaround for https://github.com/Kozea/wdb/issues/136 to avoid having to wait so long for wdb container to stop. I hope I can revert that part soon.