### PR TITLE
[DCK] Change tecnativa/postfix-relay for tvial/docker-mailserver

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -40,16 +40,30 @@ services:
         image: mailhog/mailhog
 
     smtpreal:
-        image: tecnativa/postfix-relay
+        image: tvial/docker-mailserver:latest
+        domainname: "$SMTP_REAL_MAILNAME"
+        stop_grace_period: 1m
         volumes:
-            - smtp:/var/spool/postfix
+            - mailconfig:/tmp/docker-mailserver:z
+            - maildata:/var/mail:z
+            - maillogs:/var/log/mail:z
+            - mailstate:/var/mail-state:z
+        cap_add:
+            - SYS_PTRACE
         environment:
-            MAILNAME: "$SMTP_REAL_MAILNAME"
-            MAIL_RELAY_HOST: "$SMTP_REAL_RELAY_HOST"
-            MAIL_RELAY_PORT: "$SMTP_REAL_RELAY_PORT"
-            MAIL_RELAY_USER: "$SMTP_REAL_RELAY_USER"
-            MAIL_CANONICAL_DOMAINS: "$SMTP_REAL_CANONICAL_DOMAINS"
-            MAIL_NON_CANONICAL_DEFAULT: "$SMTP_REAL_NON_CANONICAL_DEFAULT"
+            DEFAULT_RELAY_HOST: "[$SMTP_REAL_RELAY_HOST]:$SMTP_REAL_RELAY_PORT"
+            DMS_DEBUG: 0
+            ENABLE_SRS: 1
+            ONE_DIR: 1
+            PERMIT_DOCKER: connected-networks
+            POSTFIX_MESSAGE_SIZE_LIMIT: 52428800 # 50 MiB
+            RELAY_HOST: "$SMTP_REAL_RELAY_HOST"
+            RELAY_PORT: "$SMTP_REAL_RELAY_PORT"
+            RELAY_USER: "$SMTP_REAL_RELAY_USER"
+            SMTP_ONLY: 1
+            SRS_DOMAINNAME: "$SMTP_REAL_NON_CANONICAL_DEFAULT"
+            SRS_EXCLUDE_DOMAINS: "$SMTP_REAL_CANONICAL_DOMAINS"
+            SRS_SENDER_CLASSES: envelope_sender,header_sender
 
     backup:
         image: tecnativa/duplicity:postgres-s3

--- a/prod.yaml
+++ b/prod.yaml
@@ -72,4 +72,7 @@ volumes:
     backup_cache:
     filestore:
     db:
-    smtp:
+    mailconfig:
+    maildata:
+    maillogs:
+    mailstate:


### PR DESCRIPTION
This community-maintained image does the same as `tecnativa/postfix-relay`, plus:

- Big community and support.
- CI.
- Can serve as a real SMTP + IMAP4 + POP3 server if you need it.
- Supports DKIM, SPF, LDAP, DMARC, LE, and many other acronyms out of the box.

WIP until merged:

- [x] https://github.com/tomav/docker-mailserver/pull/1331
- [x] https://github.com/tomav/docker-mailserver/pull/1332
- [x] https://github.com/tomav/docker-mailserver/pull/1333 (not exactly required but I wanted to link it here for future reference).

TODO:

- [x] Test in production.
- [x] Notify backwards incompatibility:
  - Env variable renamed: MAIL_RELAY_PASS :arrow_right: RELAY_PASSWORD

@Tecnativa TT20505