### PR TITLE
[DCK] Add init to backup container

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -55,6 +55,7 @@ services:
         image: tecnativa/duplicity:postgres-s3
         hostname: backup
         domainname: "$DOMAIN_PROD"
+        init: true
         environment:
             DST: "s3://s3.amazonaws.com/$BACKUP_S3_BUCKET"
             EMAIL_FROM: "$BACKUP_EMAIL_FROM"


### PR DESCRIPTION
Duplicity spins sometimes a gpg-agent process that keeps living in this container.

Adding an init process to avoid zombie processes when this container is stopped.