### PR TITLE
Revert "Switch to new S3 URI (#62)"

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -71,7 +71,7 @@ services:
         domainname: "$DOMAIN_PROD"
         init: true
         environment:
-            DST: "s3://$BACKUP_S3_BUCKET.s3.amazonaws.com"
+            DST: "s3://s3.amazonaws.com/$BACKUP_S3_BUCKET"
             EMAIL_FROM: "$BACKUP_EMAIL_FROM"
             EMAIL_TO: "$BACKUP_EMAIL_TO"
             PGDATABASE: *dbname


### PR DESCRIPTION

@yelizariev I have to revert commit 1bf8a8f0d5e9af713a11ed89ea3cdabfb097da3a.

The backup container started failing with: `BackendException: Boto requires a bucket name.`

I guess we can re-merge #62 once that's fixed. Sorry :confused: 