### PR TITLE
[DCK] Enable proxy buffering

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -19,6 +19,7 @@ services:
         volumes:
             - filestore:/var/lib/odoo:z
         labels:
+            traefik.backend.buffering.retryExpression: IsNetworkError() && Attempts() < 5
             traefik.docker.network: "inverseproxy_shared"
             traefik.enable: "true"
             traefik.frontend.passHostHeader: "true"


### PR DESCRIPTION
Apply https://github.com/odoo/odoo/issues/20158#issuecomment-586957943 to avoid that issue, but for Traefik v1.7, which is the one supported here for now.

TT21841