### PR TITLE
Development: use ssh agent forwarding

### DIFF
--- a/setup-devel.yaml
+++ b/setup-devel.yaml
@@ -26,12 +26,15 @@ services:
             - public
         volumes:
             - ./odoo/custom/src:/opt/odoo/custom/src:rw,z
+            # XXX Uncomment to fetch private repositories
+            #- $SSH_AUTH_SOCK:/ssh-agent
         environment:
             DEPTH_DEFAULT: 100
             # XXX Export these variables before running setup to own the files
             UID: "${UID:-1000}"
             GID: "${GID:-1000}"
             UMASK: "$UMASK"
+            SSH_AUTH_SOCK: "/ssh-agent"
         user: root
         entrypoint: autoaggregate
 


### PR DESCRIPTION
This simplifies working with private repositories.

Using deployment ssh keys in  /opt/odoo/custom/ssh is not really convenient, because
github requires unique ssh key per repository, which means that some complicated configuration is needed to clone the repos (if it's even possible). Coping personal ssh keys into the docker is not good idea either.

On the other hand, some developers may not trust their keys inside this blackbox, so make them commented by default 

Credits: https://gist.github.com/d11wtq/8699521